### PR TITLE
Fix: false positives in chat filter messages

### DIFF
--- a/voidext.cs
+++ b/voidext.cs
@@ -64,7 +64,8 @@ namespace Voidext
             foreach (string w in shitlist)
             {
                 if (commandConf.ChatFilterToggle==false) return;
-                if (message.Contains(w))
+                var pattern = "\b" + w + "\b";
+                if (System.Text.RegularExpressions.Regex.IsMatch(message, pattern, System.Text.RegularExpressions.RegexOptions.IgnoreCase))
                 {
                     switch(commandConf.filteraction)
                     {


### PR DESCRIPTION
Using a pattern match (regex) solves the issue of partial matches applying unintentionally.

e.g.: the filter term `fag` should not trigger a match for someone discussing how they like to prepare their favorite Italian dish `fagioli`.

These changes simply wrap the user-defined search terms in word-boundary tokens and replace the call to `String.contains` with a `Regex.IsMatch` expression.